### PR TITLE
Override HTTP(S) schema detection via env variable.

### DIFF
--- a/www/simple.php
+++ b/www/simple.php
@@ -99,11 +99,9 @@ if($_SERVER['SERVER_PORT']!=443 && $_SERVER['SERVER_PORT']!=80) {
 function getScheme() {
     if(isset($_SERVER['OVERRIDE_HTTPS']) && $_SERVER['OVERRIDE_HTTPS']) {
         return 'https';
-    }
-    elseif(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+    } else if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
         return 'https';
-    }
-    else {
+    } else {
         return 'http';
     }
 }

--- a/www/simple.php
+++ b/www/simple.php
@@ -96,11 +96,16 @@ if($_SERVER['SERVER_PORT']!=443 && $_SERVER['SERVER_PORT']!=80) {
 	$port='';
 }
 
-
-function getScheme()
-{
-	$scheme = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http';	
-	return $scheme;
+function getScheme() {
+    if(isset($_SERVER['OVERRIDE_HTTPS']) && $_SERVER['OVERRIDE_HTTPS']) {
+        return 'https';
+    }
+    elseif(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+        return 'https';
+    }
+    else {
+        return 'http';
+    }
 }
 
 


### PR DESCRIPTION
This commit adds the functionality to override the schema detection via an environment variable "OVERRIDE_HTTPS".

A use-case for this is having the website sitting on a HTTP-only web server (say Apache for example). That web server is then served to the outside network via a reverse proxy which has a SSL certificate enabled.

The code originally did not know to use HTTPS for the redirection URL in this case (as the back-end server is not SSL-enabled). This change allows the administrator to set an env variable which will force the code to use HTTPS for the redirect URL.