### PR TITLE
Optional value autoredirect on config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Visit: `https://yourserver.com/autoregister/?client=hubic&password=mypassword&hu
 
 It will get fill the form and send it back without user intervention.
 
-Remove comment for `autoredirect_uri` on `config.php` in case you need to force the redirect to a certain URI. For example, if you want to access to use `https://yourserver.com:8080/autoregister/?client=hubic&password=mypassword&hubic_user=myhubiclogin&hubic_password=myhubicpassword`, that internally is a redirection to port 80 inside there is a VM or a container, then you could use:
+Remove comment and set your value for `autoredirect_uri` on `config.php` in case you need to force the redirect to a certain URI. For example, if you want to access to use `https://yourserver.com:8080/autoregister/?client=hubic&password=mypassword&hubic_user=myhubiclogin&hubic_password=myhubicpassword`, that internally is a redirection to port 80 inside a VM or a container, then you could use:
 
 ```php
      'autoredirect_uri'=>'https://localhost/callback/', // only needed for autoregister in some cases

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Visit: `https://yourserver.com/autoregister/?client=hubic&password=mypassword&hu
 
 It will get fill the form and send it back without user intervention.
 
+Remove comment for `autoredirect_uri` on `config.php` in case you need to force the redirect to a certain URI. For example, if you want to access to use `https://yourserver.com:8080/autoregister/?client=hubic&password=mypassword&hubic_user=myhubiclogin&hubic_password=myhubicpassword`, that internally is a redirection to port 80 inside there is a VM or a container, then you could use:
+
+```php
+     'autoredirect_uri'=>'https://localhost/callback/', // only needed for autoregister in some cases
+```
+
 ###  Configuring the Swift Clients
 
 To use it with "any" client supporting openstack swift protocol you need to set those up similiar to these examples:

--- a/config.php.sample
+++ b/config.php.sample
@@ -1,6 +1,7 @@
 <?php
 $clients=array(
 	'hubic'=>array(
+//		'autoredirect_uri'=>'https://localhost/callback/', // only needed for autoregister in some cases
 		'password'=>'mypassword',
 		'client_id'=>'api_hubic_xxxx...(put yours here)',
 		'client_secret'=>'xxxx......(put yours here)'

--- a/www/simple.php
+++ b/www/simple.php
@@ -253,9 +253,13 @@ if($mode=='autoregister') {
 	$hubic_user = $_GET['hubic_user'];
 	$hubic_password = $_GET['hubic_password'];
 
+        if (is_array($clients[$client]) && array_key_exists('autoredirect_uri', $clients[$client])) {
+		$redirect_uri = $clients[$client]['autoredirect_uri'];
+	}
+
 	$formdata = array (
 		'client_id' => $client_id,
-		'redirect_uri' => urlencode(getScheme()."://".$_SERVER['SERVER_NAME'].$port.$_prefix."/callback/"),
+		'redirect_uri' => urlencode($redirect_uri),
 		'scope' => 'usage.r,account.r,getAllLinks.r,credentials.r,activate.w,links.drw',
 		'response_type' => 'code',
 		'state' => $client.':'.md5($client_id)


### PR DESCRIPTION
Remove comment and set your value for autoredirect_uri on config.php in case you need to force the redirect to a certain URI. For example, if you want to access to use `https://yourserver.com:8080/autoregister/?client=hubic&password=mypassword&hubic_user=myhubiclogin&hubic_password=myhubicpassword``, that internally is a redirection to port 80 inside a VM or a container, then you could use:

```php
     'autoredirect_uri'=>'https://localhost/callback/', // only needed for autoregister in some cases
```